### PR TITLE
Fix icon path after restructuring of material sources

### DIFF
--- a/materialx/emoji.py
+++ b/materialx/emoji.py
@@ -22,7 +22,7 @@ def _patch_index(options):
     """Patch the given index."""
 
     icon_locations = options.get('custom_icons', [])[:]
-    icon_locations.append(os.path.join(RESOURCES, '.icons'))
+    icon_locations.append(os.path.join(RESOURCES, 'templates', '.icons'))
     return _patch_index_for_locations(tuple(icon_locations))
 
 


### PR DESCRIPTION
After we restructured the project in https://github.com/squidfunk/mkdocs-material/commit/56b96b4d799174d48d36613d70ffac9b964171cc in order to better split plugins and templates, icons don't work anymore. This PR fixes the path from which icons are sourced.